### PR TITLE
Reduce the Flatpak size

### DIFF
--- a/org.kde.kbibtex.json
+++ b/org.kde.kbibtex.json
@@ -16,12 +16,15 @@
     "cleanup": [
         "/include",
         "/lib/cmake",
+        "/lib/girepository-1.0",
         "/lib/pkgconfig",
-        "*.a",
-        "*.la",
+        "/share/doc",
         "/share/man",
+        "/share/gir-1.0",
         "/share/pkgconfig",
-        "/share/qlogging-categories5"
+        "/share/qlogging-categories5",
+        "*.la",
+        "*.a"
     ],
     "modules": [
         {


### PR DESCRIPTION
The installed size reduced from 41.0 MB to 38.3 MB.

KDE apps usually open an external website for help documentation.

Therefore, it's not required to keep the /share/doc folder.