### PR TITLE
Use openjpeg module from runtime

### DIFF
--- a/org.kde.kbibtex.json
+++ b/org.kde.kbibtex.json
@@ -49,28 +49,6 @@
             ]
         },
         {
-            "name": "openjpeg",
-            "buildsystem": "cmake-ninja",
-            "builddir": true,
-            "cleanup": [
-                "/bin",
-                "/lib/openjpeg-*"
-            ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://github.com/uclouvain/openjpeg/archive/v2.5.4.tar.gz",
-                    "sha256": "a695fbe19c0165f295a8531b1e4e855cd94d0875d2f88ec4b61080677e27188a",
-                    "x-checker-data": {
-                        "type": "anitya",
-                        "project-id": 2550,
-                        "stable-only": true,
-                        "url-template": "https://github.com/uclouvain/openjpeg/archive/v$version.tar.gz"
-                    }
-                }
-            ]
-        },
-        {
             "name": "poppler",
             "buildsystem": "cmake-ninja",
             "config-opts": [


### PR DESCRIPTION
KDE runtime version 5.15-24.08 (based on the Freedesktop runtime version 24.08) appears to provide the openjpeg module.

Fixes: https://github.com/flathub/org.kde.kbibtex/issues/79